### PR TITLE
Do not depend on distutils for Noble

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -19,7 +19,6 @@ Build-Depends: cmake,
                protobuf-compiler,
                python3,
                python3-dev,
-               python3-distutils,
                python3-pybind11,
                uuid-dev,
                libzmq3-dev (>= 3.0.0),
@@ -214,7 +213,6 @@ Package: python3-gz-transport14
 Architecture: any
 Depends:
      libgz-transport14 (= ${binary:Version}),
-     python3-distutils,
      python3-pybind11,
      python3-gz-msgs11,
      ${shlibs:Depends},


### PR DESCRIPTION
Same as: https://github.com/gazebo-release/gz-transport13-release/commit/59e0386f5a41a9d7d6e9719883ec0606d42f125b

Should fix debbuilders on Noble for gz-transport main.

cc: @azeey @j-rivero 